### PR TITLE
Document what unit of time `per()` accepts

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Basic usage: `var limited = limit(fn);`
 	```
 
 - `limited.to(count=1)`: The number of times `fn` will be execute within the time specified by `.per(time)`.
-- `limited.per(time=Infinity)`: The period of time in which `fn` will be executed `.to(count)` number of times.
+- `limited.per(time=Infinity)`: The number of milliseconds in which `fn` will be executed `.to(count)` number of times.
 - `limited.evenly([toggle=true])`: Off by default.  When true, `fn` will be executed evenly through the time period specified by `.per(time)`.  For example, if set to true and `.to(10)` and `.per(1000)`, then `fn` will be executed every 100ms.
 - `limited.withFuzz([percent=0.1])`: Set to 0 by default.  Adds a random factor to the delay time.  For example if set to 0.1 and `.to(10)` and `.per(1000)`, then `fn` will be executed between every 100ms to 110ms.
 


### PR DESCRIPTION
The unit of time that `per()` expects should be documented, but isn't.

I'm guessing it's milliseconds, so this patch adjusts the language to reflect that detail.
